### PR TITLE
Avoid unnecessary dependencies when using FormatterConfig

### DIFF
--- a/resources/default-hxformat.json
+++ b/resources/default-hxformat.json
@@ -103,7 +103,8 @@
 		}
 	},
 	"excludes": [
-		"\\.haxelib"
+		"\\.haxelib",
+		"\\.git"
 	],
 	"indentation": {
 		"character": "tab",

--- a/resources/hxformat-schema.json
+++ b/resources/hxformat-schema.json
@@ -75,7 +75,7 @@
 					"$ref": "#/definitions/formatter.config.WhitespacePolicy"
 				},
 				"formatStringInterpolation": {
-					"description": "should formatter try to format string interpolation expressions (e.g. '${x+3}' -> '${x + 3}')\r\n\t\tonly applies spaces, no newlines or wrapping",
+					"description": "should formatter try to format string interpolation expressions (e.g. '${x+3}' -> '${x + 3}') only applies spaces, no newlines or wrapping\n",
 					"type": "boolean"
 				},
 				"typeExtensionPolicy": {
@@ -241,7 +241,7 @@
 					"$ref": "#/definitions/formatter.config.WrapRules"
 				},
 				"arrayWrap": {
-					"description": "array wrapping rules\r\n\t\tdoes not affect array comprehension, use \"sameLine.comprehensionFor\"",
+					"description": "array wrapping rules does not affect array comprehension, use \"sameLine.comprehensionFor\"\n",
 					"$ref": "#/definitions/formatter.config.WrapRules"
 				},
 				"maxLineLength": {
@@ -303,7 +303,7 @@
 					"type": "integer"
 				},
 				"betweenImportsLevel": {
-					"description": "restrict betweenImports setting to a specific level\r\n\t\t\"all\" - apply betweenImports to all imports/using entries\r\n\t\t\"topLevelPackage\" - group imports/using entries using toplevel package names; no empty lines for identical toplevel names\r\n\t\t\"packages\" - group imports/using entries using full packages; no empty lines for identical package names",
+					"description": "restrict betweenImports setting to a specific level \"all\" - apply betweenImports to all imports/using entries\n\"topLevelPackage\" - group imports/using entries using toplevel package names; no empty lines for identical toplevel names \"packages\" - group imports/using entries using full packages; no empty lines for identical package names\n",
 					"$ref": "#/definitions/formatter.config.BetweenImportsEmptyLinesLevel"
 				},
 				"beforeUsing": {
@@ -433,11 +433,11 @@
 			"additionalProperties": false,
 			"properties": {
 				"disableFormatting": {
-					"description": "turns off formatting for all files in current folder and subfolders\r\n\t\tunless subfolder contains a \"hxformat.json\"",
+					"description": "turns off formatting for all files in current folder and subfolders unless subfolder contains a `hxformat.json`\n",
 					"type": "boolean"
 				},
 				"excludes": {
-					"description": "regular expressions matching files to exclude from formatting\r\n\t\tdefault ist to exclude any \".haxelib\" folder",
+					"description": "regular expressions matching files to exclude from formatting default is to exclude any `.haxelib` and `.git` folder\n",
 					"items": {
 						"type": "string"
 					},
@@ -529,14 +529,14 @@
 			"additionalProperties": false,
 			"properties": {
 				"tryBody": {
-					"description": "same line policy for non block body of \"try\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"try\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"comprehensionFor": {
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"ifElse": {
-					"description": "same line policy for \"else\" part of \"if…else\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for \"else\" part of \"if…else\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"expressionCase": {
@@ -546,62 +546,62 @@
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"doWhile": {
-					"description": "same line policy for \"while\" part in \"do…while\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for \"while\" part in \"do…while\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"expressionIfWithBlocks": {
-					"description": "will place if with one expression in a block in one line (requires \"expressionIf\" = \"same\")\r\n\t\tvar foo = if (bar) { \"\"; } else { \"\"; };",
+					"description": "will place if with one expression in a block in one line (requires \"expressionIf\" = \"same\") var foo = if (bar) { \"\"; } else { \"\"; };\n",
 					"type": "boolean"
 				},
 				"catchBody": {
-					"description": "same line policy for non block body of \"catch\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"catch\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"elseIf": {
-					"description": "same line policy for \"if\" part of \"else if\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for \"if\" part of \"else if\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"functionBody": {
-					"description": "same line policy for non block body of \"function\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"function\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"expressionIf": {
-					"description": "same line policy for non block body of \"if\" in a value place / as expression\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"if\" in a value place / as expression * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"ifBody": {
-					"description": "same line policy for non block body of \"if\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"if\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"caseBody": {
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"elseBody": {
-					"description": "same line policy for non block body of \"else\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"else\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"tryCatch": {
-					"description": "same line policy for \"catch\" part of \"try…catch\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for \"catch\" part of \"try…catch\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"doWhileBody": {
-					"description": "same line policy for non block body of \"do…while\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"do…while\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"returnBody": {
-					"description": "same line policy for return values\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for return values * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"anonFunctionBody": {
-					"description": "same line policy for non block body of anon \"function\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of anon \"function\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"forBody": {
-					"description": "same line policy for non block body of \"for\"\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"for\" * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				},
 				"whileBody": {
-					"description": "same line policy for non block body of \"while\" (not \"do…while\")\r\n\t\t* same = place function and body on same line\r\n\t\t* next = place body on next line\r\n\t\t* keep = keep same / next line from source",
+					"description": "same line policy for non block body of \"while\" (not \"do…while\") * same = place function and body on same line\n* next = place body on next line * keep = keep same / next line from source\n",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy"
 				}
 			},
@@ -689,7 +689,7 @@
 					"$ref": "#/definitions/formatter.config.ClassFieldsEmptyLinesConfig"
 				},
 				"beforeDocCommentEmptyLines": {
-					"description": "\"one\" adds one empty line above doc comments\r\n\t\t\"none\" removes all empty lines above doc comments\r\n\t\t\"ignore\" respects empty lines set via \"betweenVars\", \"betweenFunctions\", etc.",
+					"description": "\"one\" adds one empty line above doc comments \"none\" removes all empty lines above doc comments\n\"ignore\" respects empty lines set via \"betweenVars\", \"betweenFunctions\", etc.",
 					"$ref": "#/definitions/formatter.config.CommentEmptyLinesPolicy"
 				},
 				"interfaceEmptyLines": {
@@ -821,7 +821,7 @@
 					"type": "string"
 				},
 				"conditionalPolicy": {
-					"description": "only applies to non inlined conditionals\r\n\t\t\"fixedZero\" = all conditional statements should start in column 1\r\n\t\t\"aligned\" = conditional statements share indentation of surrounding code\r\n\t\t\"alignedIncrease\" = same as \"aligned\" but will increase indent by +1 for enclosed code\r\n\t\t\"alignedDecrease\" = same as \"aligned\" but will decrease indent by -1 for enclosed code",
+					"description": "only applies to non inlined conditionals \"fixedZero\" = all conditional statements should start in column 1\n\"aligned\" = conditional statements share indentation of surrounding code \"alignedIncrease\" = same as \"aligned\" but will increase indent by +1 for enclosed code\n\"alignedDecrease\" = same as \"aligned\" but will decrease indent by -1 for enclosed code",
 					"$ref": "#/definitions/formatter.config.ConditionalIndentationPolicy"
 				},
 				"tabWidth": {
@@ -869,7 +869,7 @@
 			"additionalProperties": false,
 			"properties": {
 				"conditions": {
-					"description": "list of conditions\r\n\t\twrapping selects a rule if all of its conditions evaluate to true",
+					"description": "list of conditions wrapping selects a rule if all of its conditions evaluate to true\n",
 					"items": {
 						"$ref": "#/definitions/formatter.config.WrapCondition"
 					},
@@ -924,7 +924,7 @@
 					"type": "integer"
 				},
 				"rules": {
-					"description": "list of wrapping rules\r\n\t\twrapping uses only the first rule whose conditions evaluates to true",
+					"description": "list of wrapping rules wrapping uses only the first rule whose conditions evaluates to true\n",
 					"items": {
 						"$ref": "#/definitions/formatter.config.WrapRule"
 					},

--- a/src/formatter/config/FormatterConfig.hx
+++ b/src/formatter/config/FormatterConfig.hx
@@ -3,7 +3,7 @@ package formatter.config;
 typedef FormatterConfig = {
 	/**
 		turns off formatting for all files in current folder and subfolders
-		unless subfolder contains a "hxformat.json"
+		unless subfolder contains a `hxformat.json`
 	**/
 	@:default(false) @:optional var disableFormatting:Bool;
 	@:default(auto) @:optional var emptyLines:EmptyLinesConfig;
@@ -15,7 +15,7 @@ typedef FormatterConfig = {
 
 	/**
 		regular expressions matching files to exclude from formatting
-		default ist to exclude any ".haxelib" folder
+		default is to exclude any `.haxelib` and `.git` folder
 	**/
-	@:default(["\\.haxelib"]) @:optional var excludes:Array<String>;
+	@:default(["\\.haxelib", "\\.git"]) @:optional var excludes:Array<String>;
 }

--- a/src/formatter/import.hx
+++ b/src/formatter/import.hx
@@ -2,12 +2,12 @@ package formatter;
 
 #if tokentree
 import byte.ByteData;
+import haxe.io.Bytes;
+import haxe.macro.Expr;
 import haxeparser.Data;
 import tokentree.TokenTree;
 import tokentree.TokenTreeAccessHelper;
 import tokentree.utils.TokenTreeCheckUtils;
-import haxe.io.Bytes;
-import haxe.macro.Expr;
 import formatter.codedata.ParsedCode;
 import formatter.codedata.TokenInfo;
 

--- a/src/formatter/import.hx
+++ b/src/formatter/import.hx
@@ -1,15 +1,17 @@
 package formatter;
 
+#if tokentree
 import byte.ByteData;
-import haxe.io.Bytes;
-import haxe.macro.Expr;
 import haxeparser.Data;
 import tokentree.TokenTree;
 import tokentree.TokenTreeAccessHelper;
 import tokentree.utils.TokenTreeCheckUtils;
+import haxe.io.Bytes;
+import haxe.macro.Expr;
 import formatter.codedata.ParsedCode;
 import formatter.codedata.TokenInfo;
 
 using StringTools;
 using tokentree.TokenTreeAccessHelper;
 using formatter.config.WhitespacePolicy;
+#end


### PR DESCRIPTION
Right now, importing `FormatterConfig` pulls in tokentree, hxparse and haxeparser, which is annoying for schema generation in vshaxe.