### PR TITLE
Keep empty lines on anon functions. Fixes issue #644

### DIFF
--- a/src/formatter/marker/MarkEmptyLines.hx
+++ b/src/formatter/marker/MarkEmptyLines.hx
@@ -1126,6 +1126,9 @@ class MarkEmptyLines extends MarkerBase {
 				block = func.access().firstChild().firstOf(BrOpen).token;
 			}
 			if (block == null) {
+				block = func.access().firstOf(BrOpen).token;
+			}
+			if (block == null) {
 				continue;
 			}
 			var fullPos:Position = block.getPos();

--- a/test/testcases/emptylines/issue_644_keep_empty_lines_in_anon_function.hxtest
+++ b/test/testcases/emptylines/issue_644_keep_empty_lines_in_anon_function.hxtest
@@ -1,0 +1,18 @@
+{
+}
+
+---
+
+final a = function() {
+	1;
+
+	1;
+}
+
+---
+
+final a = function() {
+	1;
+
+	1;
+}


### PR DESCRIPTION
Includes a test case for the issue.

I noticed that anonymous functions weren't getting the block token in `keepExistingEmptyLines` so I added a new attempt at extracting it (this time looking at the direct children of the function token).
I'm unsure if this is the right way to fix it but it seems to do the trick.
