### PR TITLE
Make excludes working

### DIFF
--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -175,8 +175,8 @@ class Cli {
 				Sys.exit(3);
 			}
 			var config = Formatter.loadConfig(paths[0]);
-
-			var result:Result = Formatter.format(Code(content.toString()), config);
+			var filePath = new Path(paths[0]);
+			var result:Result = Formatter.format(Code(content.toString(), SourceFile(filePath.file)), config);
 			switch (result) {
 				case Success(formattedCode):
 					Sys.println(formattedCode);
@@ -204,8 +204,9 @@ class Cli {
 			if (verbose) {
 				verboseLogFile(path, config);
 			}
+			var filePath = new Path(path);
 			var content:String = File.getContent(path);
-			var result:Result = Formatter.format(Code(content), config);
+			var result:Result = Formatter.format(Code(content, SourceFile(filePath.file)), config);
 			switch (result) {
 				case Success(formattedCode):
 					FormatStats.incSuccess();
@@ -218,7 +219,7 @@ class Cli {
 								exitCode = 1;
 							}
 						case CheckStability:
-							var secondResult = Formatter.format(Code(formattedCode), config);
+							var secondResult = Formatter.format(Code(formattedCode, SourceFile(filePath.file)), config);
 							function unstable() {
 								Sys.println('Unstable formatting in $path');
 								exitCode = 1;

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -175,8 +175,7 @@ class Cli {
 				Sys.exit(3);
 			}
 			var config = Formatter.loadConfig(paths[0]);
-			var filePath = new Path(paths[0]);
-			var result:Result = Formatter.format(Code(content.toString(), SourceFile(filePath.file)), config);
+			var result:Result = Formatter.format(Code(content.toString(), SourceFile(paths[0])), config);
 			switch (result) {
 				case Success(formattedCode):
 					Sys.println(formattedCode);
@@ -204,9 +203,8 @@ class Cli {
 			if (verbose) {
 				verboseLogFile(path, config);
 			}
-			var filePath = new Path(path);
 			var content:String = File.getContent(path);
-			var result:Result = Formatter.format(Code(content, SourceFile(filePath.file)), config);
+			var result:Result = Formatter.format(Code(content, SourceFile(path)), config);
 			switch (result) {
 				case Success(formattedCode):
 					FormatStats.incSuccess();
@@ -219,7 +217,7 @@ class Cli {
 								exitCode = 1;
 							}
 						case CheckStability:
-							var secondResult = Formatter.format(Code(formattedCode, SourceFile(filePath.file)), config);
+							var secondResult = Formatter.format(Code(formattedCode, SourceFile(path)), config);
 							function unstable() {
 								Sys.println('Unstable formatting in $path');
 								exitCode = 1;

--- a/src/formatter/Formatter.hx
+++ b/src/formatter/Formatter.hx
@@ -66,9 +66,12 @@ class Formatter {
 					range: range
 				};
 				return formatInputData(inputData);
-			case Tokens(tokenList, tokenTree, code):
+			case Tokens(tokenList, tokenTree, code, origin):
 				inputData = {
-					fileName: "<unknown.hx>",
+					fileName: switch (origin) {
+						case SourceFile(fileName): fileName;
+						case Snippet: "code snippet";
+					},
 					content: code,
 					tokenList: tokenList,
 					tokenTree: tokenTree,
@@ -186,7 +189,7 @@ enum FormatterInput {
 	FileInput(fileName:String);
 	#end
 	Code(code:String, origin:CodeOrigin);
-	Tokens(tokenList:Array<Token>, tokenTree:TokenTree, code:Bytes);
+	Tokens(tokenList:Array<Token>, tokenTree:TokenTree, code:Bytes, origin:CodeOrigin);
 }
 
 enum CodeOrigin {

--- a/src/formatter/Formatter.hx
+++ b/src/formatter/Formatter.hx
@@ -52,10 +52,13 @@ class Formatter {
 				};
 				return formatInputData(inputData);
 			#end
-			case Code(code):
+			case Code(code, origin):
 				var content:Bytes = Bytes.ofString(code);
 				inputData = {
-					fileName: "code snippet",
+					fileName: switch (origin) {
+						case SourceFile(fileName): fileName;
+						case Snippet: "code snippet";
+					},
 					content: content,
 					config: config,
 					lineSeparator: lineSeparator,
@@ -165,7 +168,7 @@ class Formatter {
 
 	#if (js && !nodejs)
 	public static function main() {
-		var result:Result = Formatter.format(Code(" trace ( 'foo' ) ; "), new Config(), ExpressionLevel);
+		var result:Result = Formatter.format(Code(" trace ( 'foo' ) ; ", Snippet), new Config(), ExpressionLevel);
 		switch (result) {
 			case Success(formattedCode):
 				js.Browser.console.log("Success: " + formattedCode);
@@ -182,6 +185,11 @@ enum FormatterInput {
 	#if (sys || nodejs)
 	FileInput(fileName:String);
 	#end
-	Code(code:String);
+	Code(code:String, origin:CodeOrigin);
 	Tokens(tokenList:Array<Token>, tokenTree:TokenTree, code:Bytes);
+}
+
+enum CodeOrigin {
+	SourceFile(fileName:String);
+	Snippet;
 }

--- a/test/GoldBaseTest.hx
+++ b/test/GoldBaseTest.hx
@@ -12,13 +12,13 @@ class GoldBaseTest {
 	function goldCheck(fileName:String, unformatted:String, goldCode:String, lineSeparator:String, ?configString:String, ?pos:PosInfos) {
 		var config = new Config();
 		config.readConfigFromString(configString, "goldhxformat.json");
-		var result:Result = Formatter.format(Code(unformatted), config, lineSeparator, entryPoint);
+		var result:Result = Formatter.format(Code(unformatted, SourceFile(fileName)), config, lineSeparator, entryPoint);
 		handleResult(fileName, result, goldCode, pos);
 
 		// second run to make sure result is stable
 		switch (result) {
 			case Success(formattedCode):
-				result = Formatter.format(Code(formattedCode), config, lineSeparator, entryPoint);
+				result = Formatter.format(Code(formattedCode, SourceFile(fileName)), config, lineSeparator, entryPoint);
 				handleResult(fileName, result, goldCode, pos);
 			case Failure(errorMessage):
 			case Disabled:

--- a/test/GoldBaseTest.hx
+++ b/test/GoldBaseTest.hx
@@ -26,8 +26,9 @@ class GoldBaseTest {
 	}
 
 	function handleResult(fileName:String, result:Result, goldCode:String, ?pos:PosInfos) {
-		var isDisabled:Bool = fileName.startsWith("disabled_");
-		var isFailing:Bool = fileName.startsWith("failing_");
+		var file = new haxe.io.Path(fileName).file;
+		var isDisabled:Bool = file.startsWith("disabled_");
+		var isFailing:Bool = file.startsWith("failing_");
 
 		switch (result) {
 			case Success(formattedCode):

--- a/test/SelfTest.hx
+++ b/test/SelfTest.hx
@@ -34,7 +34,7 @@ class SelfTest {
 
 	function checkFile(fileName:String, ?pos:PosInfos) {
 		var code:String = File.getContent(fileName);
-		var result = Formatter.format(Code(code), Formatter.loadConfig(fileName));
+		var result = Formatter.format(Code(code, SourceFile(fileName)), Formatter.loadConfig(fileName));
 		switch (result) {
 			case Success(formattedCode):
 				if (code != formattedCode) {

--- a/test/TestCaseMacro.hx
+++ b/test/TestCaseMacro.hx
@@ -40,7 +40,7 @@ class TestCaseMacro {
 		return (macro class {
 			@Test
 			public function $fieldName() {
-				goldCheck($v{fieldName}, $v{unformatted}, $v{gold}, $v{lineSeparator}, $v{config});
+				goldCheck($v{fileName}, $v{unformatted}, $v{gold}, $v{lineSeparator}, $v{config});
 			};
 		}).fields[0];
 	}

--- a/test/formatter/EmptyLinesTest.hx
+++ b/test/formatter/EmptyLinesTest.hx
@@ -90,7 +90,7 @@ class EmptyLinesTest {
 	function format(unformatted:String, ?pos:PosInfos):String {
 		var config = new Config();
 		config.readConfigFromString("{}", "goldhxformat.json");
-		var result:Result = Formatter.format(Code(unformatted), config, null, TypeLevel);
+		var result:Result = Formatter.format(Code(unformatted, Snippet), config, null, TypeLevel);
 		switch (result) {
 			case Success(formattedCode):
 				return formattedCode;

--- a/test/testcases/FormatRangeTestCases.hx
+++ b/test/testcases/FormatRangeTestCases.hx
@@ -22,7 +22,8 @@ class FormatRangeTestCases extends GoldBaseTest {
 		}
 		unformatted = unformatted.replace("]<", "");
 
-		var result:Result = Formatter.format(Code(unformatted), config, lineSeparator, entryPoint, {startPos: startIndex, endPos: endIndex});
+		var result:Result = Formatter.format(Code(unformatted, SourceFile(fileName)), config, lineSeparator, entryPoint,
+			{startPos: startIndex, endPos: endIndex});
 		handleResult(fileName, result, goldCode, pos);
 	}
 }

--- a/test/testcases/other/disabled_excluded.hxtest
+++ b/test/testcases/other/disabled_excluded.hxtest
@@ -1,5 +1,5 @@
 {
-	"excludes": ["disabled_excluded"]
+	"excludes": ["test\/testcases\/other\/disabled_excluded.hxtest"]
 }
 
 ---

--- a/test/testcases/other/disabled_excluded.hxtest
+++ b/test/testcases/other/disabled_excluded.hxtest
@@ -1,5 +1,5 @@
 {
-	"excludes": [".*"]
+	"excludes": ["disabled_excluded"]
 }
 
 ---


### PR DESCRIPTION
Make excludes working by making inputData's fileName actually refer to file name of the file where code being formatted is coming from