### PR TITLE
If;else new line option

### DIFF
--- a/resources/default-hxformat.json
+++ b/resources/default-hxformat.json
@@ -159,6 +159,7 @@
 		"functionBody": "next",
 		"ifBody": "next",
 		"ifElse": "same",
+		"ifElseNextLineSemicolon": true,
 		"returnBody": "same",
 		"returnBodySingleLine": "same",
 		"tryBody": "next",

--- a/resources/hxformat-schema.json
+++ b/resources/hxformat-schema.json
@@ -771,6 +771,11 @@
 					"$ref": "#/definitions/formatter.config.SameLinePolicy",
 					"default": "next"
 				},
+				"ifElseNextLineSemicolon": {
+					"description": "Add new line after `if body` to `if (...) body; else ...` Don't touch `if (...) body else ...` or `if (...) {body} else ...`",
+					"type": "boolean",
+					"default": true
+				},
 				"returnBody": {
 					"description": "same line policy for multiline expression return values * same = place return and body on same line * next = place body on next line * keep = keep same / next line from source",
 					"$ref": "#/definitions/formatter.config.SameLinePolicy",

--- a/src/formatter/config/SameLineConfig.hx
+++ b/src/formatter/config/SameLineConfig.hx
@@ -26,6 +26,12 @@ typedef SameLineConfig = {
 	@:default(Same) @:optional var ifElse:SameLinePolicy;
 
 	/**
+		Add new line after `if body` to `if (...) body; else ...`
+		Don't touch `if (...) body else ...` or `if (...) {body} else ...`
+	**/
+	@:default(true) @:optional var ifElseSemicolonNextLine:Bool;
+
+	/**
 		same line policy for "if" part of "else if"
 		* same = place if and body on same line
 		* next = place body on next line

--- a/src/formatter/marker/MarkSameLine.hx
+++ b/src/formatter/marker/MarkSameLine.hx
@@ -230,6 +230,15 @@ class MarkSameLine extends MarkerBase {
 							case Keep:
 						}
 					}
+				case Semicolon:
+					if (config.sameLine.ifElseSemicolonNextLine) {
+						switch (policy) {
+							case Same:
+								policy = Next;
+							case Next:
+							case Keep:
+						}
+					}
 				default:
 			}
 		}

--- a/test/testcases/sameline/issue_612_else_block.hxtest
+++ b/test/testcases/sameline/issue_612_else_block.hxtest
@@ -1,0 +1,62 @@
+{
+	"sameLine": {
+		"ifBody": "same",
+		"elseBody": "same",
+		"ifElse": "same",
+		"ifElseSemicolonNextLine": true
+	}
+}
+
+---
+
+class Main {
+
+	static function main():Void {
+		if (true) foo else foo;
+		if (true) foo else {
+			foo;
+		}
+
+		if (true) foo; else {
+			foo;
+		}
+		if (true) foo; else foo;
+
+		if (true) {
+			foo;
+		} else foo;
+		if (true) {
+			foo;
+		} else {
+			foo;
+		}
+	}
+
+}
+
+---
+
+class Main {
+	static function main():Void {
+		if (true) foo else foo;
+		if (true) foo else {
+			foo;
+		}
+
+		if (true) foo;
+		else {
+			foo;
+		}
+		if (true) foo;
+		else foo;
+
+		if (true) {
+			foo;
+		} else foo;
+		if (true) {
+			foo;
+		} else {
+			foo;
+		}
+	}
+}


### PR DESCRIPTION
Changes `if (true) foo; else foo;` to two lines, but does not touch
`if (true) foo else foo;`
`if (true) {foo} else foo;`

Enabled by default, but maybe you want to keep current behavior and select better naming.
Closes #612