### PR TITLE
Add custom file extension support

### DIFF
--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -19,7 +19,7 @@ class Cli {
 	var mode:Mode = Format;
 	var exitCode:Int = 0;
 	var lastConfigFileName:Null<String>;
-	var extension:String;
+	var extension:String = "hx";
 
 	function new() {
 		var args = Sys.args();
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension?.toString() ?? "hx",
+			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension.toString(),
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -19,6 +19,7 @@ class Cli {
 	var mode:Mode = Format;
 	var exitCode:Int = 0;
 	var lastConfigFileName:Null<String>;
+	var extension:String;
 
 	function new() {
 		var args = Sys.args();
@@ -46,8 +47,17 @@ class Cli {
 		var help = false;
 		var pipemode = false;
 		var argHandler = hxargs.Args.generate([
-			@doc("File or directory with .hx files to format (multiple allowed)")
+			@doc("File or directory with haxe files to format (multiple allowed)")
 			["-s", "--source"] => function(path:String) paths.push(path),
+
+			@doc("File extension to use, defaults to hx")
+			["-e", "--extension"] => function(fileExtension:String) {
+				#if (haxe_ver >= 4.3)
+				extension = fileExtension?.toString() ?? "hx";
+				#else
+				extension = if (fileExtension != null) fileExtension.toString() else "hx";
+				#end
+			},
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,
@@ -198,7 +208,7 @@ class Cli {
 	}
 
 	function formatFile(path:String) {
-		if (path.endsWith(".hx")) {
+		if (path.endsWith("." + extension)) {
 			var config = Formatter.loadConfig(path);
 			if (verbose) {
 				verboseLogFile(path, config);

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -51,13 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) {
-				#if (haxe_ver >= 4.3)
-				extension = fileExtension?.toString() ?? "hx";
-				#else
-				extension = if (fileExtension != null) fileExtension.toString() else "hx";
-				#end
-			},
+			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension?.toString() ?? "hx",
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,


### PR DESCRIPTION
This PR adds a file extension argument (`-e`/`--extension`) to the CLI which defaults to `hx`. Useful if you want to format stuff like HScript files, but don't want to manually rename them to `.hx` first.

Example usage:
```
haxelib run formatter -s . -e hxc
```
This formats every file in the current directory (recursively) with the `.hxc` file extension.