### PR TITLE
Fix if you include an "." in the file extension

### DIFF
--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = StringTools.replace(fileExtension.toString(), ".", ""),
+			["-e", "--extension"] => function(fileExtension:String) extension = "." + StringTools.replace(fileExtension.toString(), ".", ""), // https://try.haxe.org/#f0564E03
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,
@@ -202,7 +202,7 @@ class Cli {
 	}
 
 	function formatFile(path:String) {
-		if (path.endsWith("." + extension)) {
+		if (path.endsWith(extension)) {
 			var config = Formatter.loadConfig(path);
 			if (verbose) {
 				verboseLogFile(path, config);

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension.replace(fileExtension, ".", ""), // https://try.haxe.org/#d42dc902
+			["-e", "--extension"] => function(fileExtension:String) extension = "." + fileExtension.replace(".", ""), // https://try.haxe.org/#d42dc902
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -19,7 +19,7 @@ class Cli {
 	var mode:Mode = Format;
 	var exitCode:Int = 0;
 	var lastConfigFileName:Null<String>;
-	var extension:String = "hx";
+	var extension:String = ".hx";
 
 	function new() {
 		var args = Sys.args();
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = "." + StringTools.replace(fileExtension.toString(), ".", ""), // https://try.haxe.org/#f0564E03
+			["-e", "--extension"] => function(fileExtension:String) extension = "." + fileExtension.replace(fileExtension, ".", ""), // https://try.haxe.org/#d42dc902
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = "." + fileExtension.replace(fileExtension, ".", ""), // https://try.haxe.org/#d42dc902
+			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension.replace(fileExtension, ".", ""), // https://try.haxe.org/#d42dc902
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,

--- a/src/formatter/Cli.hx
+++ b/src/formatter/Cli.hx
@@ -51,7 +51,7 @@ class Cli {
 			["-s", "--source"] => function(path:String) paths.push(path),
 
 			@doc("File extension to use, defaults to hx")
-			["-e", "--extension"] => function(fileExtension:String) extension = fileExtension.toString(),
+			["-e", "--extension"] => function(fileExtension:String) extension = StringTools.replace(fileExtension.toString(), ".", ""),
 
 			@doc("Read code from stdin and print formatted output to stdout (needs _one_ -s <path> for reference in configuration detection)")
 			["--stdin"] => function() pipemode = true,


### PR DESCRIPTION
It's already handled later in the code, but not when the user includes an "." themselves, this makes sure that doesn't happen so you don't get `..hxc` instead of `.hxc`